### PR TITLE
Fix path to sales orders in composer.json 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "autoload": {
     "psr-4": {
       "Vendasta\\SalesOrders\\V1\\": "./src",
-      "Salesorders\\V1\\": "./generated/grpc/SalesOrders/V1",
+      "Salesorders\\V1\\": "./generated/grpc/Salesorders/V1",
       "Sales\\V1\\": "./generated/grpc/Sales/V1",
       "GPBMetadata\\MarketplaceApps\\V1\\": "./generated/grpc/GPBMetadata/MarketplaceApps/V1",
       "GPBMetadata\\Sales\\V1\\": "./generated/grpc/GPBMetadata/Sales/V1",


### PR DESCRIPTION
Fix path in composer.json. SalesOrders is straight up incorrect, the folder name ([here](https://github.com/vendasta/sales-orders-php-sdk/tree/master/generated/grpc)) is `Salesorders`

@vendasta/lucky-charms 