### PR TITLE
Give SalesOrdersUtils::buildField a field type input.

### DIFF
--- a/src/SalesOrdersUtils.php
+++ b/src/SalesOrdersUtils.php
@@ -48,15 +48,20 @@ class SalesOrdersUtils {
      * @param string $fieldId the ID of the field
      * @param string $fieldLabel the label of the field
      * @param string $answer the answer for this field on the Order
+     * @param int $fieldType the type of field this is. Use the FieldType enumerator. Defaults to Text field.
      * @return Field an initialized Field
      */
-    public static function buildField(string $fieldId, string $fieldLabel, string $answer): Field
+    public static function buildField(string $fieldId, string $fieldLabel, string $answer, int $fieldType = FieldType::TEXT): Field
     {
+        $formattedAnswer = $answer;
+        if ($fieldType === FieldType::TEXT || $fieldType === FieldType::TEXTAREA) {
+            $formattedAnswer = "\"" . $answer . "\"";
+        }
         $field = new Field();
         $field->setFieldId($fieldId);
-        $field->setFieldType(FieldType::TEXT);
+        $field->setFieldType($fieldType);
         $field->setLabel($fieldLabel);
-        $field->setAnswer("\"" . $answer . "\"");
+        $field->setAnswer($formattedAnswer);
 
         return $field;
     }

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -76,7 +76,7 @@ class SalesOrdersClientTest extends TestCase
         $customFields = array($gSuiteCustomField);
 
         // Create the order
-        $order = SalesOrdersUtils::buildOrder("ABC", "AG-WZ3WGGDB7F", $lineItems, $customFields);
+        $order = SalesOrdersUtils::buildOrder("PID", "AG-123", $lineItems, $customFields);
         $req->setOrder($order);
 
         try {

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -2,6 +2,8 @@
 
 use PHPUnit\Framework\TestCase;
 use Salesorders\V1\CreateAndActivateOrderRequest;
+use Salesorders\V1\CustomField;
+use Salesorders\V1\FieldType;
 use Vendasta\SalesOrders\V1\SalesOrdersClient;
 use Vendasta\SalesOrders\V1\SalesOrdersUtils;
 use Vendasta\Vax\SDKException;
@@ -32,6 +34,49 @@ class SalesOrdersClientTest extends TestCase
 
         // Create the order
         $order = SalesOrdersUtils::buildOrder("ABC", "AG-123", $lineItems, $customFields);
+        $req->setOrder($order);
+
+        try {
+            $resp = $client->CreateAndActivateOrder($req);
+        } catch (SDKException $e) {
+            self::fail($e);
+        }
+        self::assertNotEmpty(
+            $resp->getOrderId(),
+            'expected order ID'
+        );
+    }
+
+    public function testCreateAndActivateTransferAppOrder()
+    {
+        // Setup the client
+        $environment = getenv("ENVIRONMENT");
+        if ($environment == null) {
+            $environment = "DEMO";
+        }
+        $client = new SalesOrdersClient($environment);
+
+        // Create the request
+        $req = new CreateAndActivateOrderRequest();
+
+        // Create the line items
+        $gSuite = SalesOrdersUtils::buildLineItem('MP-7TMH5K8N7KNNRZ5NC4RNNS2JFK64HMNC');
+        $lineItems = array($gSuite);
+
+        // Create the custom field
+        $gSuiteCustomField = new CustomField();
+        $gSuiteCustomField->setProductId('MP-7TMH5K8N7KNNRZ5NC4RNNS2JFK64HMNC');
+
+        $domain = SalesOrdersUtils::buildField('domain', 'Domain Name', "domain.com", FieldType::TEXT,);
+        $transferToken = SalesOrdersUtils::buildField('transfer_token',  'Transfer Token', "TOKEN123TOKEN", FieldType::TEXT,);
+        $autoTransfer = SalesOrdersUtils::buildField('auto_transfer', 'Automatic Transfer', "true", FieldType::CHECKBOX);
+
+        $gSuiteFields = array($transferToken, $domain, $autoTransfer);
+        $gSuiteCustomField->setFields($gSuiteFields);
+        $customFields = array($gSuiteCustomField);
+
+        // Create the order
+        $order = SalesOrdersUtils::buildOrder("ABC", "AG-WZ3WGGDB7F", $lineItems, $customFields);
         $req->setOrder($order);
 
         try {


### PR DESCRIPTION
In order to support more order form fields I updated `buildField` to have a fieldType input. It defaults to a text field so that the change isn't breaking.

Also added a test using the generic util functions instead of using the G Suite specific helper function

@vendasta/lucky-charms 