### PR TITLE
[GLO-2154] add method buildGoDaddyCustomFieldsForTransfer and tests

### DIFF
--- a/src/SalesOrdersUtils.php
+++ b/src/SalesOrdersUtils.php
@@ -161,4 +161,50 @@ class SalesOrdersUtils {
         return $goDaddyCustomField;
 
     }
+
+    /**
+     * Creates a CustomField for GoDaddy for a transfer order
+     *
+     * @param string $productId the app/product ID for the GoDaddy product
+     * @param string $domain the domain being purchased (ex. google.com)
+     * @param string $adminEmail the email of the domain admin (ex. user@example.com)
+     * @param string $adminFirstName the first name of the domain admin
+     * @param string $adminLastName the last name of the domain admin
+     * @param string $adminPhone the phone number for the domain admin
+     * @param string $ownerEmail the email of the domain owner
+     * @param string $ownerFirstName the first name of the domain owner
+     * @param string $ownerLastName the last name of the domain owner
+     * @param string $authCode the authorization code for the transfer
+     * @param string $zoneFile double escaped string containing the text in the zone file for the domain
+     * @param string $nameServer1 first custom name server if applicable. Leave this blank if keeping default name servers
+     * @param string $nameServer2 second custom name server if applicable. Leave this blank if keeping default name servers
+     * @param string $nameServer3 third custom name server if applicable. Leave this blank if keeping default name servers
+     * @return CustomField An initialized custom field for a GoDaddy order
+     */
+    public static function buildGoDaddyCustomFieldsForTransfer(string $productId, string $domain, string $adminEmail, string $adminFirstName, string $adminLastName, string $adminPhone, string $ownerEmail, string $ownerFirstName, string $ownerLastName, string $authCode, string $zoneFile, string $nameServer1, string $nameServer2, string $nameServer3): CustomField
+    {
+        $goDaddyCustomField = new CustomField();
+        $goDaddyCustomField->setProductId($productId);
+
+        $goDaddyDomain = self::buildField('domain', 'Domain Selection', $domain);
+        $goDaddyAdminEmail = self::buildField('email', 'Admin Email Address', $adminEmail);
+        $goDaddyAdminFirstName = self::buildField('first_name', 'Admin First Name', $adminFirstName);
+        $goDaddyAdminLastName = self::buildField('last_name', 'Admin Last Name', $adminLastName);
+        $goDaddyAdminPhone = self::buildField('phone', 'Admin Phone Number', $adminPhone);
+        $goDaddyOwnerEmail = self::buildField('shopper_email', 'Domain Owner Email', $ownerEmail);
+        $goDaddyOwnerFirstName = self::buildField('shopper_first_name', 'Domain Owner First Name', $ownerFirstName);
+        $goDaddyOwnerLastName = self::buildField('shopper_last_name', 'Domain Owner Last Name', $ownerLastName);
+        $goDaddyAuthCode = self::buildField('auth_code', 'Auth Code', $authCode);
+        $goDaddyZoneFile = self::buildField('zone_file', 'Zone File', $zoneFile, FieldType::TEXTAREA);
+        $goDaddyNameServer1 = self::buildField('nameserver1', 'Nameserver 1', $nameServer1);
+        $goDaddyNameServer2 = self::buildField('nameserver2', 'Nameserver 2', $nameServer2);
+        $goDaddyNameServer3 = self::buildField('nameserver3', 'Nameserver 3', $nameServer3);
+        $goDaddyIsTransfer = self::buildField('is_transfer', 'Purchased through a transfer',"true", FieldType::CHECKBOX);
+
+        $goDaddyFields = array($goDaddyDomain, $goDaddyAdminEmail, $goDaddyAdminFirstName, $goDaddyAdminLastName, $goDaddyAdminPhone, $goDaddyOwnerEmail, $goDaddyOwnerFirstName, $goDaddyOwnerLastName, $goDaddyAuthCode, $goDaddyZoneFile, $goDaddyNameServer1, $goDaddyNameServer2, $goDaddyNameServer3, $goDaddyIsTransfer);
+        $goDaddyCustomField->setFields($goDaddyFields);
+
+        return $goDaddyCustomField;
+
+    }
 }

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -141,11 +141,10 @@ _domainconnect	3600	 IN 	CNAME	_domainconnect.ss.domaincontrol.com.
 @	3600	 IN 	NS	ns40.domaincontrol.com.
 
 ";
-        $zonefileEscaped = addslashes($zoneFile);
-        $zoneFile2 = "\n\$ORIGIN example.com.\\r\\n\\r\\n\\t;SOARecord\\r\\n\\t@\\t3600\\tIN\\tSOA\\tns39.domaincontrol.com.\\tdns.jomax.net.(\\r\\n\\t\\t2021060702\\r\\n\\t28800\\r\\n\\t7200\\r\\n\\t604800\\r\\n\\t3600\\r\\n\\t)\\r\\n\\r\\n\\t;ARecords\\r\\n\\t@\\t3600\\tIN\\tA\\t100.100.100.100\\r\\n\\r\\n\\t;CNAMERecords\\r\\n\\twww\\t3600\\tIN\\tCNAME\\t@\\r\\n\\t_domainconnect\\t3600\\tIN\\tCNAME\\t_domainconnect.ss.domaincontrol.com.\\r\\n\\r\\n\\t;MXRecords\\r\\n\\t@\\t3600\\t IN \\tMX\\t0\\tmail.example.com.\\r\\n\\r\\n\\t;TXTRecords\\r\\n\\r\\n\\t;SRVRecords\\r\\n\\t_sip._tcp.example.com.   86400 IN    SRV 10       60     5060 example.example.com.\\r\\n\\r\\n\\t;AAAARecords\\r\\n\\r\\n\\t;CAARecords\\r\\n\\r\\n\\t;NSRecords\\r\\n\\t@\\t3600\\tIN\\tNS\\tns10.domaincontrol.com.\\r\\n\\t@\\t3600\\tIN\\tNS\\tns11.domaincontrol.com.\\r\\n";
+        $zoneFile = "\$ORIGIN luckycharmsteam.com.\\r\\n\\r\\n; SOA Record\\r\\n@\\t3600\\t IN \\tSOA\\tns39.domaincontrol.com.\\tdns.jomax.net. (\\r\\n\\t\\t\\t\\t\\t2021060800\\r\\n\\t\\t\\t\\t\\t28800\\r\\n\\t\\t\\t\\t\\t7200\\r\\n\\t\\t\\t\\t\\t604800\\r\\n\\t\\t\\t\\t\\t3600\\r\\n\\t\\t\\t\\t\\t) \\r\\n\\r\\n; A Records\\r\\n@\\t3600\\t IN \\tA\\t104.154.100.138\\r\\n\\r\\n; CNAME Records\\r\\nwww\\t3600\\t IN \\tCNAME\\t@\\r\\n_domainconnect\\t3600\\t IN \\tCNAME\\t_domainconnect.ss.domaincontrol.com.\\r\\n\\r\\n; MX Records\\r\\n\\r\\n; TXT Records\\r\\n@\\t1800\\t IN \\tTXT\\t\\\"google-site-verification=wUvRFCYFmKdWGSkk82winL_D_tvO0TKUnP3cCpPhgo8\\\"\\r\\n\\r\\n; SRV Records\\r\\n\\r\\n; AAAA Records\\r\\n\\r\\n; CAA Records\\r\\n\\r\\n; NS Records\\r\\n@\\t3600\\t IN \\tNS\\tns39.domaincontrol.com.\\r\\n@\\t3600\\t IN \\tNS\\tns40.domaincontrol.com.\\r\\n";
 
         // Create the custom field
-        $goDaddyCustomField = SalesOrdersUtils::buildGoDaddyCustomFieldsForTransfer("MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ", "testdomain123.com", "example@email.com", "First", "Last", "3065555555", "example@email.com", "First", "Last", "AuthCode", $zonefileEscaped, "NameServer1", "NameServer2", "NameServer3");
+        $goDaddyCustomField = SalesOrdersUtils::buildGoDaddyCustomFieldsForTransfer("MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ", "testdomain123.com", "example@email.com", "First", "Last", "3065555555", "example@email.com", "First", "Last", "AuthCode", $zoneFile, "NameServer1", "NameServer2", "NameServer3");
         $customFields = array($goDaddyCustomField);
 
         // Create the order

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -107,8 +107,7 @@ class SalesOrdersClientTest extends TestCase
         $goDaddy = SalesOrdersUtils::buildLineItem('MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ');
         $lineItems = array($goDaddy);
 
-        $zoneFile = "\$ORIGIN luckycharmsteam.com.\\r\\n\\r\\n; SOA Record\\r\\n@\\t3600\\t IN \\tSOA\\tns39.domaincontrol.com.\\tdns.jomax.net. (\\r\\n\\t\\t\\t\\t\\t2021060800\\r\\n\\t\\t\\t\\t\\t28800\\r\\n\\t\\t\\t\\t\\t7200\\r\\n\\t\\t\\t\\t\\t604800\\r\\n\\t\\t\\t\\t\\t3600\\r\\n\\t\\t\\t\\t\\t) \\r\\n\\r\\n; A Records\\r\\n@\\t3600\\t IN \\tA\\t104.154.100.138\\r\\n\\r\\n; CNAME Records\\r\\nwww\\t3600\\t IN \\tCNAME\\t@\\r\\n_domainconnect\\t3600\\t IN \\tCNAME\\t_domainconnect.ss.domaincontrol.com.\\r\\n\\r\\n; MX Records\\r\\n\\r\\n; TXT Records\\r\\n@\\t1800\\t IN \\tTXT\\t\\\"google-site-verification=wUvRFCYFmKdWGSkk82winL_D_tvO0TKUnP3cCpPhgo8\\\"\\r\\n\\r\\n; SRV Records\\r\\n\\r\\n; AAAA Records\\r\\n\\r\\n; CAA Records\\r\\n\\r\\n; NS Records\\r\\n@\\t3600\\t IN \\tNS\\tns39.domaincontrol.com.\\r\\n@\\t3600\\t IN \\tNS\\tns40.domaincontrol.com.\\r\\n";
-
+        $zoneFile = '$ORIGIN example.com.\\r\\n\\r\\n; SOA Record\\r\\n@\\t3600\\t IN \\tSOA\\tns10.domaincontrol.com.\\tdns.example.net. (\\r\\n\\t\\t\\t\\t\\t1\\r\\n\\t\\t\\t\\t\\t900\\r\\n\\t\\t\\t\\t\\t7200\\r\\n\\t\\t\\t\\t\\t604800\\r\\n\\t\\t\\t\\t\\t3600\\r\\n\\t\\t\\t\\t\\t) \\r\\n\\r\\n; A Records\\r\\n@\\t3600\\t IN \\tA\\t100.100.100.100\\r\\n\\r\\n; CNAME Records\\r\\nwww\\t3600\\t IN \\tCNAME\\t@\\r\\n\\r\\n; MX Records\\r\\n\\r\\n; TXT Records\\r\\n@\\t1800\\t IN \\tTXT\\t\\"MS=ms1111111\\"\\r\\n\\r\\n; SRV Records\\r\\n\\r\\n; AAAA Records\\r\\n\\r\\n; CAA Records\\r\\n\\r\\n; NS Records\\r\\n@\\t3600\\t IN \\tNS\\tns39.domaincontrol.com.\\r\\n@\\t3600\\t IN \\tNS\\tns40.domaincontrol.com.\\r\\n\\r\\n';
         // Create the custom field
         $goDaddyCustomField = SalesOrdersUtils::buildGoDaddyCustomFieldsForTransfer("MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ", "testdomain123.com", "example@email.com", "First", "Last", "3065555555", "example@email.com", "First", "Last", "AuthCode", $zoneFile, "NameServer1", "NameServer2", "NameServer3");
         $customFields = array($goDaddyCustomField);
@@ -143,7 +142,7 @@ class SalesOrdersClientTest extends TestCase
         $lineItems = array($gSuiteAddon);
 
         // Create the order
-        $order = SalesOrdersUtils::buildOrder("ABC", "AG-123", $lineItems, []);
+        $order = SalesOrdersUtils::buildOrder("ABC", "AG-QWSGCJHZSL", $lineItems, []);
         $req->setOrder($order);
 
         try {

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -106,41 +106,7 @@ class SalesOrdersClientTest extends TestCase
         // Create the line items
         $goDaddy = SalesOrdersUtils::buildLineItem('MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ');
         $lineItems = array($goDaddy);
-        $zoneFile = "
-\$ORIGIN luckycharmsteam.com.
 
-; SOA Record
-@	3600	 IN 	SOA	ns39.domaincontrol.com.	dns.jomax.net. (
-					2021060800
-					28800
-					7200
-					604800
-					3600
-					) 
-
-; A Records
-@	3600	 IN 	A	104.154.100.138
-
-; CNAME Records
-www	3600	 IN 	CNAME	@
-_domainconnect	3600	 IN 	CNAME	_domainconnect.ss.domaincontrol.com.
-
-; MX Records
-
-; TXT Records
-@	1800	 IN 	TXT	\"google-site-verification=wUvRFCYFmKdWGSkk82winL_D_tvO0TKUnP3cCpPhgo8\"
-
-; SRV Records
-
-; AAAA Records
-
-; CAA Records
-
-; NS Records
-@	3600	 IN 	NS	ns39.domaincontrol.com.
-@	3600	 IN 	NS	ns40.domaincontrol.com.
-
-";
         $zoneFile = "\$ORIGIN luckycharmsteam.com.\\r\\n\\r\\n; SOA Record\\r\\n@\\t3600\\t IN \\tSOA\\tns39.domaincontrol.com.\\tdns.jomax.net. (\\r\\n\\t\\t\\t\\t\\t2021060800\\r\\n\\t\\t\\t\\t\\t28800\\r\\n\\t\\t\\t\\t\\t7200\\r\\n\\t\\t\\t\\t\\t604800\\r\\n\\t\\t\\t\\t\\t3600\\r\\n\\t\\t\\t\\t\\t) \\r\\n\\r\\n; A Records\\r\\n@\\t3600\\t IN \\tA\\t104.154.100.138\\r\\n\\r\\n; CNAME Records\\r\\nwww\\t3600\\t IN \\tCNAME\\t@\\r\\n_domainconnect\\t3600\\t IN \\tCNAME\\t_domainconnect.ss.domaincontrol.com.\\r\\n\\r\\n; MX Records\\r\\n\\r\\n; TXT Records\\r\\n@\\t1800\\t IN \\tTXT\\t\\\"google-site-verification=wUvRFCYFmKdWGSkk82winL_D_tvO0TKUnP3cCpPhgo8\\\"\\r\\n\\r\\n; SRV Records\\r\\n\\r\\n; AAAA Records\\r\\n\\r\\n; CAA Records\\r\\n\\r\\n; NS Records\\r\\n@\\t3600\\t IN \\tNS\\tns39.domaincontrol.com.\\r\\n@\\t3600\\t IN \\tNS\\tns40.domaincontrol.com.\\r\\n";
 
         // Create the custom field

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -91,6 +91,78 @@ class SalesOrdersClientTest extends TestCase
         );
     }
 
+    public function testCreateAndActivateGoDaddyTransferOrder()
+    {
+        // Setup the client
+        $environment = getenv("ENVIRONMENT");
+        if ($environment == null) {
+            $environment = "DEMO";
+        }
+        $client = new SalesOrdersClient($environment);
+
+        // Create the request
+        $req = new CreateAndActivateOrderRequest();
+
+        // Create the line items
+        $goDaddy = SalesOrdersUtils::buildLineItem('MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ');
+        $lineItems = array($goDaddy);
+        $zoneFile = "
+\$ORIGIN luckycharmsteam.com.
+
+; SOA Record
+@	3600	 IN 	SOA	ns39.domaincontrol.com.	dns.jomax.net. (
+					2021060800
+					28800
+					7200
+					604800
+					3600
+					) 
+
+; A Records
+@	3600	 IN 	A	104.154.100.138
+
+; CNAME Records
+www	3600	 IN 	CNAME	@
+_domainconnect	3600	 IN 	CNAME	_domainconnect.ss.domaincontrol.com.
+
+; MX Records
+
+; TXT Records
+@	1800	 IN 	TXT	\"google-site-verification=wUvRFCYFmKdWGSkk82winL_D_tvO0TKUnP3cCpPhgo8\"
+
+; SRV Records
+
+; AAAA Records
+
+; CAA Records
+
+; NS Records
+@	3600	 IN 	NS	ns39.domaincontrol.com.
+@	3600	 IN 	NS	ns40.domaincontrol.com.
+
+";
+        $zonefileEscaped = addslashes($zoneFile);
+        $zoneFile2 = "\n\$ORIGIN example.com.\\r\\n\\r\\n\\t;SOARecord\\r\\n\\t@\\t3600\\tIN\\tSOA\\tns39.domaincontrol.com.\\tdns.jomax.net.(\\r\\n\\t\\t2021060702\\r\\n\\t28800\\r\\n\\t7200\\r\\n\\t604800\\r\\n\\t3600\\r\\n\\t)\\r\\n\\r\\n\\t;ARecords\\r\\n\\t@\\t3600\\tIN\\tA\\t100.100.100.100\\r\\n\\r\\n\\t;CNAMERecords\\r\\n\\twww\\t3600\\tIN\\tCNAME\\t@\\r\\n\\t_domainconnect\\t3600\\tIN\\tCNAME\\t_domainconnect.ss.domaincontrol.com.\\r\\n\\r\\n\\t;MXRecords\\r\\n\\t@\\t3600\\t IN \\tMX\\t0\\tmail.example.com.\\r\\n\\r\\n\\t;TXTRecords\\r\\n\\r\\n\\t;SRVRecords\\r\\n\\t_sip._tcp.example.com.   86400 IN    SRV 10       60     5060 example.example.com.\\r\\n\\r\\n\\t;AAAARecords\\r\\n\\r\\n\\t;CAARecords\\r\\n\\r\\n\\t;NSRecords\\r\\n\\t@\\t3600\\tIN\\tNS\\tns10.domaincontrol.com.\\r\\n\\t@\\t3600\\tIN\\tNS\\tns11.domaincontrol.com.\\r\\n";
+
+        // Create the custom field
+        $goDaddyCustomField = SalesOrdersUtils::buildGoDaddyCustomFieldsForTransfer("MP-NNTJMBF6HPXR5XXC2JKCFWKJ64VZLBFQ", "testdomain123.com", "example@email.com", "First", "Last", "3065555555", "example@email.com", "First", "Last", "AuthCode", $zonefileEscaped, "NameServer1", "NameServer2", "NameServer3");
+        $customFields = array($goDaddyCustomField);
+
+        // Create the order
+        $order = SalesOrdersUtils::buildOrder("VNDR", "AG-123", $lineItems, $customFields);
+        $req->setOrder($order);
+
+        try {
+            $resp = $client->CreateAndActivateOrder($req);
+        } catch (SDKException $e) {
+            self::fail($e);
+        }
+        self::assertNotEmpty(
+            $resp->getOrderId(),
+            'expected order ID'
+        );
+    }
+
     public function testCreateAndActivateOrderForAddon() {
         // Setup the client
         $environment = getenv("ENVIRONMENT");

--- a/tests/SalesOrdersClientTest.php
+++ b/tests/SalesOrdersClientTest.php
@@ -113,7 +113,7 @@ class SalesOrdersClientTest extends TestCase
         $customFields = array($goDaddyCustomField);
 
         // Create the order
-        $order = SalesOrdersUtils::buildOrder("VNDR", "AG-123", $lineItems, $customFields);
+        $order = SalesOrdersUtils::buildOrder("ABC", "AG-123", $lineItems, $customFields);
         $req->setOrder($order);
 
         try {
@@ -142,7 +142,7 @@ class SalesOrdersClientTest extends TestCase
         $lineItems = array($gSuiteAddon);
 
         // Create the order
-        $order = SalesOrdersUtils::buildOrder("ABC", "AG-QWSGCJHZSL", $lineItems, []);
+        $order = SalesOrdersUtils::buildOrder("ABC", "AG-123", $lineItems, []);
         $req->setOrder($order);
 
         try {


### PR DESCRIPTION
Add the helper method `buildGoDaddyCustomFieldsForTransfer` and a test to demonstrate how to use this method to transfer a domain into our GoDaddy reseller. Right now the zone file will only be parsed correctly if it is escaped twice using [this](https://www.freeformatter.com/json-escape.html) formatter. I have included this information in the [draft](https://docs.google.com/document/d/1cJE5GYzpP91QBOv68K1RbqB_CMMXwO3ViWkpUqir6BE/edit?usp=sharing) documentation we will provide to Houzz, but will continue looking into how we can parse this in the sdk if yall think this will cause formatting issues. 

[GLO-2154]

@vendasta/lucky-charms 

[GLO-2154]: https://vendasta.jira.com/browse/GLO-2154